### PR TITLE
Return better error when API call returns error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/go-fed/httpsig v1.1.0
 	github.com/gruntwork-io/terratest v0.41.10
-	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
+	github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/gruntwork-io/terratest v0.41.10 h1:yb6O5iZjwDFMyoDeWb+SKPzGaNlLddb5ip
 github.com/gruntwork-io/terratest v0.41.10/go.mod h1:qH1xkPTTGx30XkMHw8jAVIbzqheSjIa5IyiTwSV2vKI=
 github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845 h1:H+uM0Bv88eur3ZSsd2NGKg3YIiuXxwxtlN7HjE66UTU=
 github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845/go.mod h1:c1tRKs5Tx7E2+uHGSyyncziFjvGpgv4H2HrqXeUQ/Uk=
+github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0 h1:nHoRIX8iXob3Y2kdt9KsjyIb7iApSvb3vgsd93xb5Ow=
+github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0/go.mod h1:c1tRKs5Tx7E2+uHGSyyncziFjvGpgv4H2HrqXeUQ/Uk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
If a non-2xx HTTP response is received, attempt to decode the response
and include the "message" attribute in the error.

Fixes #1
